### PR TITLE
Add consumption metric from Billing API

### DIFF
--- a/changelog/unreleased/consumption-metrics.md
+++ b/changelog/unreleased/consumption-metrics.md
@@ -1,0 +1,6 @@
+Enhancement: Add metrics for consumption statistics
+
+We've added new metrics for the consumption API endpoints to give an overview
+about consumed and billed resources.
+
+https://github.com/promhippie/scw_exporter/pull/114

--- a/docs/partials/envvars.md
+++ b/docs/partials/envvars.md
@@ -43,6 +43,12 @@ SCW_EXPORTER_ZONE
 SCW_EXPORTER_COLLECTOR_DASHBOARD
 : Enable collector for dashboard, defaults to `true`
 
+SCW_EXPORTER_COLLECTOR_CONSUMPTION
+: Enable collector for billing consumption, defaults to `true`
+
+SCW_EXPORTER_COLLECTOR_CONSUMPTION_LABELS
+: List of labels used for consumptions, comma-separated list, defaults to `category_name, product_name, project_id, resource_name, sku, unit`
+
 SCW_EXPORTER_COLLECTOR_SECURITY_GROUPS
 : Enable collector for security groups, defaults to `true`
 

--- a/pkg/action/server.go
+++ b/pkg/action/server.go
@@ -196,6 +196,18 @@ func handler(cfg *config.Config, logger *slog.Logger, client *scw.Client) *chi.M
 		mux.Mount("/debug", middleware.Profiler())
 	}
 
+	if cfg.Collector.Consumption {
+		logger.Debug("Consumption collector registered")
+
+		registry.MustRegister(exporter.NewConsumptionCollector(
+			logger,
+			client,
+			requestFailures,
+			requestDuration,
+			cfg.Target,
+		))
+	}
+
 	if cfg.Collector.Dashboard {
 		logger.Debug("Dashboard collector registered")
 

--- a/pkg/command/command.go
+++ b/pkg/command/command.go
@@ -171,8 +171,15 @@ func RootFlags(cfg *config.Config) []cli.Flag {
 			Name:        "collector.consumption",
 			Value:       true,
 			Usage:       "Enable collector for billing consumption",
-			EnvVars:     []string{"SCW_EXPORTER_COLLECTOR_CONSUMPTION"},
+			Sources:     cli.EnvVars("SCW_EXPORTER_COLLECTOR_CONSUMPTION"),
 			Destination: &cfg.Collector.Consumption,
+		},
+		&cli.StringSliceFlag{
+			Name:        "collector.consumption.labels",
+			Value:       config.ConsumptionLabels(),
+			Usage:       "List of labels used for consumptions",
+			Sources:     cli.EnvVars("SCW_EXPORTER_COLLECTOR_CONSUMPTION_LABELS"),
+			Destination: &cfg.Target.Consumption.Labels,
 		},
 		&cli.BoolFlag{
 			Name:        "collector.security-groups",

--- a/pkg/command/command.go
+++ b/pkg/command/command.go
@@ -168,6 +168,13 @@ func RootFlags(cfg *config.Config) []cli.Flag {
 			Destination: &cfg.Collector.Dashboard,
 		},
 		&cli.BoolFlag{
+			Name:        "collector.consumption",
+			Value:       true,
+			Usage:       "Enable collector for billing consumption",
+			EnvVars:     []string{"SCW_EXPORTER_COLLECTOR_CONSUMPTION"},
+			Destination: &cfg.Collector.Consumption,
+		},
+		&cli.BoolFlag{
 			Name:        "collector.security-groups",
 			Value:       true,
 			Usage:       "Enable collector for security groups",

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -37,6 +37,7 @@ type Target struct {
 // Collector defines the collector specific configuration.
 type Collector struct {
 	Dashboard      bool
+	Consumption    bool
 	SecurityGroups bool
 	Servers        bool
 	Baremetal      bool

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -23,15 +23,21 @@ type Logs struct {
 	Pretty bool
 }
 
+// Consumption defines the config for the consumption collector.
+type Consumption struct {
+	Labels []string
+}
+
 // Target defines the target specific configuration.
 type Target struct {
-	AccessKey string
-	SecretKey string
-	Org       string
-	Project   string
-	Region    string
-	Zone      string
-	Timeout   time.Duration
+	AccessKey   string
+	SecretKey   string
+	Org         string
+	Project     string
+	Region      string
+	Zone        string
+	Timeout     time.Duration
+	Consumption Consumption
 }
 
 // Collector defines the collector specific configuration.
@@ -56,6 +62,18 @@ type Config struct {
 // Load initializes a default configuration struct.
 func Load() *Config {
 	return &Config{}
+}
+
+// ConsumptionLabels defines the default labels used by consumption collector.
+func ConsumptionLabels() []string {
+	return []string{
+		"category_name",
+		"product_name",
+		"project_id",
+		"resource_name",
+		"sku",
+		"unit",
+	}
 }
 
 // Value returns the config value based on a DSN.

--- a/pkg/exporter/consumption.go
+++ b/pkg/exporter/consumption.go
@@ -1,0 +1,131 @@
+package exporter
+
+import (
+	"log/slog"
+	"strconv"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/promhippie/scw_exporter/pkg/config"
+
+	billing "github.com/scaleway/scaleway-sdk-go/api/billing/v2beta1"
+	"github.com/scaleway/scaleway-sdk-go/scw"
+)
+
+type ConsumptionCollector struct {
+	client      *scw.Client
+	consumption *billing.API
+	logger      *slog.Logger
+	failures    *prometheus.CounterVec
+	duration    *prometheus.HistogramVec
+	config      config.Target
+	org         *string
+	project     *string
+
+	Value    *prometheus.Desc
+	Quantity *prometheus.Desc
+}
+
+func NewConsumptionCollector(logger *slog.Logger, client *scw.Client, failures *prometheus.CounterVec, duration *prometheus.HistogramVec, cfg config.Target) *ConsumptionCollector {
+	if failures != nil {
+		failures.WithLabelValues("consumption").Add(0)
+	}
+
+	labels := []string{"category_name", "product_name", "project_id", "resource_name", "sku", "unit"}
+	collector := &ConsumptionCollector{
+		client:      client,
+		consumption: billing.NewAPI(client),
+		logger:      logger.With("collector", "consumption"),
+		failures:    failures,
+		duration:    duration,
+		config:      cfg,
+
+		Value: prometheus.NewDesc(
+			"scw_consumption_value",
+			"sdasdas",
+			labels,
+			nil,
+		),
+
+		Quantity: prometheus.NewDesc(
+			"scw_consumption_billed_quantity",
+			"sdasdsadasd",
+			labels,
+			nil,
+		),
+	}
+
+	if cfg.Org != "" {
+		collector.org = scw.StringPtr(cfg.Org)
+	}
+
+	if cfg.Project != "" {
+		collector.project = scw.StringPtr(cfg.Project)
+	}
+
+	return collector
+}
+
+func (c *ConsumptionCollector) Metrics() []*prometheus.Desc {
+	return []*prometheus.Desc{
+		c.Value,
+		c.Quantity,
+	}
+}
+
+func (c *ConsumptionCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- c.Value
+	ch <- c.Quantity
+}
+
+func (c *ConsumptionCollector) Collect(ch chan<- prometheus.Metric) {
+	now := time.Now()
+
+	resp, err := c.consumption.ListConsumptions(
+		&billing.ListConsumptionsRequest{},
+		scw.WithAllPages(),
+	)
+	c.duration.WithLabelValues("consumption").Observe(time.Since(now).Seconds())
+
+	if err != nil {
+		c.logger.Error("failed to fetch consumptions",
+			"organization", c.org,
+			"err", err,
+		)
+		c.failures.WithLabelValues("consumption").Inc()
+		return
+	}
+
+	for _, consumption := range resp.Consumptions {
+
+		var (
+			value    float64
+			quantity float64
+		)
+
+		quantity, _ = strconv.ParseFloat(consumption.BilledQuantity, 64)
+
+		labels := []string{
+			consumption.CategoryName,
+			consumption.ProductName,
+			consumption.ProjectID,
+			consumption.ResourceName,
+			consumption.Sku,
+			consumption.Unit,
+		}
+
+		ch <- prometheus.MustNewConstMetric(
+			c.Value,
+			prometheus.CounterValue,
+			value,
+			labels...,
+		)
+
+		ch <- prometheus.MustNewConstMetric(
+			c.Quantity,
+			prometheus.CounterValue,
+			quantity,
+			labels...,
+		)
+	}
+}

--- a/pkg/exporter/consumption.go
+++ b/pkg/exporter/consumption.go
@@ -12,6 +12,7 @@ import (
 	"github.com/scaleway/scaleway-sdk-go/scw"
 )
 
+// ConsumptionCollector collects metrics about resources consumption.
 type ConsumptionCollector struct {
 	client      *scw.Client
 	consumption *billing.API
@@ -26,6 +27,7 @@ type ConsumptionCollector struct {
 	Quantity *prometheus.Desc
 }
 
+// NewConsumptionCollector returns a new ServerCollector.
 func NewConsumptionCollector(logger *slog.Logger, client *scw.Client, failures *prometheus.CounterVec, duration *prometheus.HistogramVec, cfg config.Target) *ConsumptionCollector {
 	if failures != nil {
 		failures.WithLabelValues("consumption").Add(0)
@@ -66,6 +68,7 @@ func NewConsumptionCollector(logger *slog.Logger, client *scw.Client, failures *
 	return collector
 }
 
+// Metrics simply returns the list metric descriptors for generating a documentation.
 func (c *ConsumptionCollector) Metrics() []*prometheus.Desc {
 	return []*prometheus.Desc{
 		c.Value,
@@ -73,11 +76,13 @@ func (c *ConsumptionCollector) Metrics() []*prometheus.Desc {
 	}
 }
 
+// Describe sends the super-set of all possible descriptors of metrics collected by this Collector.
 func (c *ConsumptionCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.Value
 	ch <- c.Quantity
 }
 
+// Collect is called by the Prometheus registry when collecting metrics.
 func (c *ConsumptionCollector) Collect(ch chan<- prometheus.Metric) {
 	now := time.Now()
 


### PR DESCRIPTION
Hello,

I'd like to add the consumption part of the Billing API of scaleway, I have almost no programming experience, even less in golang, but so far so good, with some copy/paste from other collectors, and helm from chatgpt I can retrieve some billing information and expose them in the HTTP /metrics endpoint.
Could it be interesting to have this in the exporter ?

I provide the metric in the attach text file, I export every label the endpoint provides,

``` 
scw_consumption_billed_quantity{category_name="Compute",product_name="Block Storage",project_id="xxxxxxxxxx",resource_name="Block Storage - PAR1",sku="/storage/block/ssd/storage/fr-par1",unit="gigabyte_hour"} 580616
scw_consumption_billed_quantity{category_name="Compute",product_name="PRO2-XS",project_id="xxxxxxxxxx",resource_name="PRO2-XS - FR-PAR-1",sku="/compute/pro2_xs/run_par1",unit="minute"} 2800
scw_consumption_billed_quantity{category_name="Containers",product_name="Kubernetes Kapsule",project_id="xxxxxxxxxx",resource_name="Run - PAR",sku="/k8s/control-plane/fr-par",unit="minute"} 400
scw_consumption_billed_quantity{category_name="Network",product_name="Loadbalancer IP",project_id="xxxxxxxxxx",resource_name="Loadbalancer IP - PAR1",sku="/network/loadbalancer/ip/par1",unit="ip_minute"} 400
scw_consumption_billed_quantity{category_name="Network",product_name="Loadbalancer Node GP-S",project_id="xxxxxxxxxx",resource_name="Run - PAR1",sku="/network/loadbalancer/loadbalancer-s/par1",unit="node_minute"} 400
scw_consumption_billed_quantity{category_name="Network",product_name="Private network",project_id="zzzzzzzzzzzzzz",resource_name="Private network - FR-PAR",sku="/network/vpc/private-network/fr-par",unit="minute"} 400
scw_consumption_billed_quantity{category_name="Network",product_name="Private network",project_id="xxxxxxxxxx",resource_name="Private network - FR-PAR",sku="/network/vpc/private-network/fr-par",unit="minute"} 400
scw_consumption_billed_quantity{category_name="Network",product_name="VPC Public Gateway IP",project_id="xxxxxxxxxx",resource_name="IP - FR-PAR-1",sku="/network/vpc/public-gateway/ip/fr-par-1",unit="minute"} 400
scw_consumption_billed_quantity{category_name="Network",product_name="VPC Public Gateway S",project_id="xxxxxxxxxx",resource_name="VPC GW S - FR-PAR-1",sku="/network/vpc/public-gateway/vpc-gw-s/fr-par-1",unit="minute"} 400
scw_consumption_billed_quantity{category_name="Object Storage",product_name="Internal Bandwidth",project_id="yyyyyyyyyyyyyyyy",resource_name="Intra region fr-par",sku="/storage/obj/bandwidth/to-fr-par/fr-par",unit="gigabyte_month"} 1
scw_consumption_billed_quantity{category_name="Object Storage",product_name="Internal Bandwidth",project_id="xxxxxxxxxx",resource_name="Intra region fr-par",sku="/storage/obj/bandwidth/to-fr-par/fr-par",unit="gigabyte_month"} 7
scw_consumption_billed_quantity{category_name="Object Storage",product_name="Internal Bandwidth Pack",project_id="yyyyyyyyyyyyyyyy",resource_name="Pack",sku="/storage/obj/offer/free-tier/internal-bandwidth",unit="plan"} 1
scw_consumption_billed_quantity{category_name="Object Storage",product_name="Multi-AZ Standard",project_id="yyyyyyyyyyyyyyyy",resource_name="Multi-AZ - PAR",sku="/storage/obj/usage-new-gen-bucket-standard/fr-par",unit="gigabyte_hour"} 400
scw_consumption_billed_quantity{category_name="Object Storage",product_name="Multi-AZ Standard",project_id="zzzzzzzzzzzzzz",resource_name="Multi-AZ - PAR",sku="/storage/obj/usage-new-gen-bucket-standard/fr-par",unit="gigabyte_hour"} 400
scw_consumption_billed_quantity{category_name="Object Storage",product_name="Multi-AZ Standard",project_id="xxxxxxxxxx",resource_name="Multi-AZ - AMS",sku="/storage/obj/usage-new-gen-bucket-standard/nl-ams",unit="gigabyte_hour"} 3143
scw_consumption_billed_quantity{category_name="Object Storage",product_name="Multi-AZ Standard",project_id="xxxxxxxxxx",resource_name="Multi-AZ - PAR",sku="/storage/obj/usage-new-gen-bucket-standard/fr-par",unit="gigabyte_hour"} 75615
scw_consumption_billed_quantity{category_name="Object Storage",product_name="Outgoing bandwidth free tier",project_id="yyyyyyyyyyyyyyyy",resource_name="Pack",sku="/storage/obj/offer/free-tier/external-bandwidth",unit="plan"} 1
scw_consumption_billed_quantity{category_name="Observability",product_name="Scaleway's logs",project_id="yyyyyyyyyyyyyyyy",resource_name="Scaleway's logs - FR-PAR",sku="/observability/cockpit/scw-log/fr-par",unit="gigabyte"} 1
scw_consumption_billed_quantity{category_name="Observability",product_name="Scaleway's logs",project_id="xxxxxxxxxx",resource_name="Scaleway's logs - FR-PAR",sku="/observability/cockpit/scw-log/fr-par",unit="gigabyte"} 3
scw_consumption_billed_quantity{category_name="Observability",product_name="Scaleway's logs",project_id="xxxxxxxxxx",resource_name="Scaleway's logs - NL-AMS",sku="/observability/cockpit/scw-log/nl-ams",unit="gigabyte"} 1
scw_consumption_billed_quantity{category_name="Observability",product_name="Scaleway's samples",project_id="yyyyyyyyyyyyyyyy",resource_name="Scaleway's samples - FR-PAR",sku="/observability/cockpit/scw-sample/fr-par",unit="sample"} 1
scw_consumption_billed_quantity{category_name="Observability",product_name="Scaleway's samples",project_id="yyyyyyyyyyyyyyyy",resource_name="Scaleway's samples - NL-AMS",sku="/observability/cockpit/scw-sample/nl-ams",unit="sample"} 1
scw_consumption_billed_quantity{category_name="Observability",product_name="Scaleway's samples",project_id="yyyyyyyyyyyyyyyy",resource_name="Scaleway's samples - PL-WAW",sku="/observability/cockpit/scw-sample/pl-waw",unit="sample"} 1
scw_consumption_billed_quantity{category_name="Observability",product_name="Scaleway's samples",project_id="zzzzzzzzzzzzzz",resource_name="Scaleway's samples - FR-PAR",sku="/observability/cockpit/scw-sample/fr-par",unit="sample"} 1
scw_consumption_billed_quantity{category_name="Observability",product_name="Scaleway's samples",project_id="xxxxxxxxxx",resource_name="Scaleway's samples - FR-PAR",sku="/observability/cockpit/scw-sample/fr-par",unit="sample"} 41
scw_consumption_billed_quantity{category_name="Observability",product_name="Scaleway's samples",project_id="xxxxxxxxxx",resource_name="Scaleway's samples - NL-AMS",sku="/observability/cockpit/scw-sample/nl-ams",unit="sample"} 2
scw_consumption_billed_quantity{category_name="Observability",product_name="Scaleway's samples",project_id="xxxxxxxxxx",resource_name="Scaleway's samples - PL-WAW",sku="/observability/cockpit/scw-sample/pl-waw",unit="sample"} 1
``` 


I'm not sure what makes a good label, so which one should I keep ? Also I'm puzzled with the one from sku label, it's sure the format is not correct, but it provides a lot of information about the product and the location which are not provided elsewhere.

Do you have some advice ?
